### PR TITLE
Turn off sidekiq

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -6,7 +6,7 @@ kill_timeout = 5
 
 [processes]
 web = "bin/rails fly:server"
-worker = "bundle exec sidekiq -c 1"
+# worker = "bundle exec sidekiq -c 1"
 
 [build]
   [build.args]


### PR DESCRIPTION
This sucks. Basically there's no way to get Sidekiq to not hammer redis, so I blow through my free tier redis. Gonna have to do these by hand

https://console.upstash.com/flyio/redis/7eac2dba-ffb4-48fd-a5f9-97b078c78129?tab=usage